### PR TITLE
Bump GitHub workflow actions to their latest versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v4
       with:
         go-version: ${{ matrix.go-version }}
     - name: Install staticcheck
@@ -25,7 +25,7 @@ jobs:
       run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
       shell: bash
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
     - name: Fmt
       if: matrix.platform != 'windows-latest' # :(
       run: "diff <(gofmt -d .) <(printf '')"

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ func main() {
 
 ## Differences to Cobra
 
-You have access to the `*cobra.Command` pointer so there's not much you cannot do with this project compared to the more low-level Cobra, but there's one small, but imortant difference:
+You have access to the `*cobra.Command` pointer so there's not much you cannot do with this project compared to the more low-level Cobra, but there's one small, but important difference:
 
-Cobra only treats the first level of misspelled commands as an `unknown command` with "Did you mean this?" suggestions, see [see this issue](https://github.com/spf13/cobra/pull/1500) for more context. The reason this is, is because of the ambiguity between sub command names and command arguments, but that is throwing away a very useful feature for a not very good reason. We recently rewrote [Hugo's CLI](https://github.com/gohugoio/hugo) using this poackage, and found only one sub command that needed to be adjusted to avoid this ambiguity.
+Cobra only treats the first level of misspelled commands as an `unknown command` with "Did you mean this?" suggestions, see [see this issue](https://github.com/spf13/cobra/pull/1500) for more context. The reason for this is the ambiguity between sub-command names and command arguments, but that is throwing away a very useful feature for a not very good reason. We recently rewrote [Hugo's CLI](https://github.com/gohugoio/hugo) using this package, and found only one sub command that needed to be adjusted to avoid this ambiguity.
 
 
 


### PR DESCRIPTION
This PR bumps the GitHub workflow actions to their latest versions. It also fixes two typos I spotted in `README.md`.