### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version: [1.24.x, 1.25.x]
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:


### PR DESCRIPTION
## Updates

- Go test versions: 1.24.x, 1.25.x
- GitHub Actions: updated to pinned hashes

---
Created by mygithelper