### PR TITLE
ci: Fix cache warnings by moving checkout step first

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ jobs:
         platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
@@ -26,8 +28,6 @@ jobs:
       - name: Update PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
         shell: bash
-      - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fmt
         if: matrix.platform != 'windows-latest' # :(
         run: "diff <(gofmt -d .) <(printf '')"


### PR DESCRIPTION
## Summary
- Move checkout step to be the first step in the workflow to fix "Restore cache failed" warnings
- The warning occurs because setup-go tries to cache Go modules before the source is checked out

## Test plan
- [ ] Verify the CI workflow runs without cache warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)